### PR TITLE
Rewrite and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.idea
+/.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,48 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.ssh.forward_agent = true
+  config.vm.synced_folder Dir.getwd, "/home/vagrant/roles/ansible-chronos", nfs: true
+
+  # ubuntu 14.04
+  config.vm.define 'ubuntu', primary: true do |c|
+    c.vm.network "private_network", ip: "192.168.100.3"
+    c.vm.box = "ubuntu/trusty64"
+    c.vm.provision "shell" do |s|
+      s.inline = "
+        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF;
+        DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]');
+        CODENAME=$(lsb_release -cs);
+        echo \"deb http://repos.mesosphere.com/${DISTRO} ${CODENAME} main\" | tee /etc/apt/sources.list.d/mesosphere.list
+        apt-get update -y;
+        apt-get install python-dev python-pip mesos -y;
+        pip install -U ansible;
+        service mesos-master restart
+        "
+      s.privileged = true
+    end
+  end
+
+  # centos 7:
+  config.vm.define 'centos7' do |c|
+    c.vm.network "private_network", ip: "192.168.100.5"
+    c.vm.box = "centos/7"
+    c.vm.provision "shell" do |s|
+      s.inline = "
+        hostname localhost;
+        iptables -F;
+        service iptables save;
+        rpm -Uvh http://archive.cloudera.com/cdh4/one-click-install/redhat/6/x86_64/cloudera-cdh-4-0.x86_64.rpm;
+        yum -y install zookeeper;
+        zookeeper-server-initialize --myid=1;
+        zookeeper-server start;
+        rpm -Uvh http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-2.noarch.rpm;
+        yum install -y epel-release;
+        yum -y install mesos ansible;
+        "
+      s.privileged = true
+    end
+  end
+
+end

--- a/ci/inventory
+++ b/ci/inventory
@@ -1,0 +1,2 @@
+[local]
+localhost

--- a/ci/playbook.yml
+++ b/ci/playbook.yml
@@ -1,0 +1,64 @@
+---
+- include: remove.yml
+
+- name: Test Playbook - Defaults
+  hosts: localhost
+  connection: local
+  sudo: yes
+  roles:
+    - { role: ../../ }
+  post_tasks:
+    - include: verify.yml
+- include: remove.yml
+
+
+- name: Test Playbook - No bin override
+  hosts: localhost
+  connection: local
+  sudo: yes
+  vars:
+    chronos_bin_load_options_override_enabled: yes
+    chronos_conf_options:
+      hostname: "{{ chronos_hostname }}"
+      http_port: "{{ chronos_port }}"
+      mesos_framework_name: "chronos"
+  roles:
+    - { role: ../../ }
+  post_tasks:
+    - include: verify.yml
+- include: remove.yml
+
+
+- name: Test Playbook - No Mesos Requirement
+  hosts: localhost
+  connection: local
+  sudo: yes
+  vars:
+    chronos_systemd_require_mesos: no
+  roles:
+    - { role: ../../ }
+  post_tasks:
+    - include: verify.yml
+- include: remove.yml
+
+
+- name: Test Playbook - Wait for Zookeeper
+  hosts: localhost
+  connection: local
+  sudo: yes
+  vars:
+    chronos_systemd_unit_startpre:
+      - "while true; do
+          [[ $(echo ruok | nc '{{ chronos_zk_dns }}' {{ chronos_zk_port }} 2>/dev/null) == 'imok' ]] && exit 0 || sleep 1;
+          [[ $SECONDS -ge 60 ]] && exit 1;
+        done
+        "
+  pre_tasks:
+    - name: Install netcat
+      yum: name=nc state=present
+      when: ansible_pkg_mgr == 'yum'
+  roles:
+    - { role: ../../ }
+  post_tasks:
+    - include: verify.yml
+

--- a/ci/remove.yml
+++ b/ci/remove.yml
@@ -1,0 +1,24 @@
+---
+
+- name: Remove Chronos
+  hosts: localhost
+  connection: local
+  sudo: yes
+
+  tasks:
+    - service: name=chronos state=stopped enabled=no
+      ignore_errors: yes
+
+    - yum: name=chronos,mesosphere-el-repo state=absent
+      when: ansible_pkg_mgr == 'yum'
+
+    - apt: pkg=chronos=* state=absent
+      when: ansible_pkg_mgr == 'apt'
+
+    - file: path={{ item }} state=absent
+      with_items:
+        - /usr/bin/chronos
+        - /usr/lib/systemd/system/chronos.service
+        - /etc/chronos/conf
+        - /etc/chronos
+        - /usr/local/bin/haproxy_dns_cfg

--- a/ci/verify.yml
+++ b/ci/verify.yml
@@ -1,0 +1,22 @@
+---
+
+- name: Test for Chronos service
+  shell: test -f /bin/systemctl && /bin/systemctl status chronos.service || service chronos status || status chronos
+  register: chronos_service
+  failed_when: "chronos_service.rc != 0 or ('Active: active (running)' not in chronos_service.stdout and 'start/running' not in chronos_service.stdout)"
+
+- name: Wait for Chronos to be ready
+  wait_for:
+    host: "{{ chronos_bind_address }}"
+    port: "{{ chronos_port }}"
+    state: started
+  delay: 3
+  retries: 5
+
+- name: Test for Chronos endpoint
+  uri:
+    # https://github.com/mesosphere/chaos#built-in-endpoints
+    url: "http://{{ chronos_bind_address }}:{{ chronos_port }}/ping"
+    return_content: yes
+  register: chronos_ping
+  failed_when: chronos_ping.status != 200 or 'pong' not in chronos_ping.content

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,19 +2,101 @@
 chronos_version: 2.4.0
 chronos_package_version: 0.1.20150828104228
 
+# RedHat
+chronos_yum_package_name: "chronos-{{ chronos_version }}"
+
 # # == chronos conf ==
+chronos_conf_path: /etc/chronos/conf
+chronos_sysconfig_path: /etc/sysconfig/chronos
+chronos_systemd_unit: /usr/lib/systemd/system/chronos.service
+
+# Control whether systemd service unit requires mesos-master service unit.
+chronos_systemd_require_mesos: yes
+
+# List of command or script that must be run before service unit is started.
+chronos_systemd_unit_startpre: []
+# Examples:
+#  - "/usr/local/bin/zookeeper-wait-for-listen.sh {{ chronos_zk_dns }}"
+#
+## or inline script
+#  - "while true; do
+#       [[ $(echo ruok | nc '{{ chronos_zk_dns }}' {{ chronos_zk_port }} 2>/dev/null) == 'imok' ]] && exit 0 || sleep 1;
+#       [[ $SECONDS -ge 60 ]] && exit 1;
+#     done
+#     "
+
+# Control whether we fix '/usr/bin/chronos' file.
+# By default the bin script load config from '/etc/mesos/zk', which is no always
+# desired if you want to supply your own value. Setting this to 'yes' will replace the
+# function 'load_options_and_log' in it with function below.
+# If you set this to 'no', you should override 'chronos_conf_options' variables,
+# remove both 'zk_hosts' and 'master' variables otherwise Chronos will complain about
+# duplicate values for the same argument.
+# Upcoming fix: https://github.com/mesosphere/chronos-pkg/pull/19
+chronos_bin_load_options_override_enabled: yes
+chronos_bin_load_options_override: |
+  function load_options_and_log {
+    set -x
+    # Load Chronos options from Mesos and Chronos conf files that are present.
+    # Launch main program with Syslog enabled.
+    local cmd=( run_jar )
+    # Load custom options
+    if [[ -d $conf_dir ]]
+    then
+      while read -u 9 -r -d '' path
+      do
+        local name="${path#./}"
+        if ! element_in "--${name#'?'}" "$@"
+        then
+          case "$name" in
+            '?'*) cmd+=( "--${name#'?'}" ) ;;
+            *)    cmd+=( "--$name" "$(< "$conf_dir/$name")" ) ;;
+          esac
+        fi
+      done 9< <(cd "$conf_dir" && find . -type f -not -name '.*' -print0)
+    fi
+    # Default zk and master options, if not already specified
+    if [[ -s /etc/mesos/zk ]]
+    then
+      if ! element_in "--zk_hosts" "${cmd[@]}"
+      then
+        cmd+=( --zk_hosts "$(cut -d / -f 3 /etc/mesos/zk)" )
+      fi
+      if ! element_in "--master" "${cmd[@]}"
+      then
+        cmd+=( --master "$(cat /etc/mesos/zk)" )
+      fi
+    fi
+    logged chronos "${cmd[@]}" "$@"
+  }
+
+
 mesos_zk_chroot: "mesos"
 chronos_zk_auth: ""
 chronos_zk_dns: "{{ inventory_hostname }}"
 chronos_zk_port: 2181
 chronos_zk_chroot: chronos
 chronos_zk_connect: "zk://{{ chronos_zk_dns }}:{{ chronos_zk_port }}/{{chronos_zk_chroot}}"
-
 chronos_zk_mesos_master: "zk://{{ chronos_zk_dns }}:{{ chronos_zk_port }}/{{ mesos_zk_chroot }}"
 
 chronos_hostname: "{{ inventory_hostname }}"
+chronos_bind_address: "{{ ansible_default_ipv4.address }}"
 chronos_port: 4400
 
-# TODO chronos_env_java_opts: "-Xmx512m"
+# Dictionary of configuration options for Chronos
+chronos_conf_options:
+  zk_hosts: "{{ chronos_zk_connect }}"
+  master: "{{ chronos_zk_mesos_master }}"
+  hostname: "{{ chronos_hostname }}"
+  http_port: "{{ chronos_port }}"
+  #mem_opts: "{{ chronos_env_java_opts }}"
+  mesos_framework_name: "chronos"
 
-haproxy_script_location: "/usr/local/bin"
+# TODO chronos_env_java_opts: "-Xmx512m"
+chronos_sysconfig_vars:
+  LIBPROCESS_IP: "{{ chronos_bind_address }}"
+
+# Location where HAProxy scripts are installed, e.g. "/usr/local/bin"
+haproxy_script_location: ''
+
+mesosphere_repo: "http://repos.mesosphere.com/el/{{ os_version_major }}/noarch/RPMS/{{ mesosphere_releases[os_version_major] }}"

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -3,4 +3,4 @@
   yum: name={{ mesosphere_repo }} state=present
 
 - name: Install Chronos
-  yum: name=chronos-{{chronos_version}} state=present
+  yum: name={{ chronos_yum_package_name }} state=present

--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -1,22 +1,9 @@
 ---
 
-#- name: wait for zookeeper to listen
-#  command: "/usr/local/bin/zookeeper-wait-for-listen.sh {{ inventory_hostname }}"
-#
-#- name: create zookeeper acl
-#  sudo: yes
-#  command: "{{ chronos_zk_acl_cmd }}"
-#  notify:
-#    - restart chronos
-#  when: zk_chronos_user_secret is defined
-#  run_once: true
-#  tags:
-#    - chronos
-
 - name: create chronos conf directory
   sudo: yes
   file:
-    dest: /etc/chronos/conf
+    dest: "{{ chronos_conf_path }}"
     state: directory
   tags:
     - chronos
@@ -25,76 +12,78 @@
   stat: path=/usr/lib/systemd/system/
   register: systemd_check
 
-- name: configure chronos unit file
+- name: (systemd) configure chronos unit file - requires
   sudo: yes
   replace:
-    dest: /usr/lib/systemd/system/chronos.service
-    regexp: "=network.target"
-    replace: '=mesos-master.service'
-  when: systemd_check.stat.exists == true
+    dest: "{{ chronos_systemd_unit }}"
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.replace }}"
+  with_items:
+    - regexp: '^After=((?!mesos-master.service).*)$'
+      replace: 'After=mesos-master.service \1'
+    - regexp: '^Wants=((?!mesos-master.service).*)$'
+      replace: 'Wants=mesos-master.service \1'
+  when: systemd_check.stat.exists == true and chronos_systemd_require_mesos
   notify:
-    - reload chronos
     - restart chronos
   tags:
     - chronos
 
-- name: configure chronos to wait for zookeeper before starting
+- name: (systemd) configure chronos unit file - pre start
   sudo: yes
   lineinfile:
-    dest: /usr/lib/systemd/system/chronos.service
-    line: "ExecStartPre=/usr/local/bin/zookeeper-wait-for-listen.sh {{ chronos_zk_dns }}"
+    dest: "{{ chronos_systemd_unit }}"
+    line: "ExecStartPre={{ item }}"
     insertbefore: "^ExecStart="
     state: present
+  with_items: chronos_systemd_unit_startpre
   when: systemd_check.stat.exists == true
   notify:
-    - reload chronos
     - restart chronos
   tags:
     - chronos
 
 # TODO: feels like a hack
 - name: fix chronos bin file
-  sudo: yes
   replace:
     dest: /usr/bin/chronos
-    regexp: '\[\[ -s /etc/mesos/zk \]\]'
-    replace: 'false'
+    regexp: 'function load_options_and_log(.*\s(?!function))*'
+    replace: "{{ chronos_bin_load_options_override }}\n"
+  when: chronos_bin_load_options_override_enabled
+  sudo: yes
   notify:
     - restart chronos
   tags:
     - chronos
 
 - name: set key/value options
-  sudo: yes
-  when: item.value != ""
   copy:
-    dest: /etc/chronos/conf/{{ item.key }}
+    dest: "{{ chronos_conf_path }}/{{ item.key }}"
     content: "{{ item.value }}"
-  with_items:
-    - key: zk_hosts
-      value: "{{ chronos_zk_connect }}"
-    - key: master
-      value: "{{ chronos_zk_mesos_master }}"
-    - key: hostname
-      value: "{{ chronos_hostname }}"
-    - key: http_port
-      value: "{{ chronos_port }}"
-    #- key: mem_opts
-    #  value: "{{ chronos_env_java_opts }}"
-    - key: mesos_framework_name
-      value: "chronos"
+  with_dict: chronos_conf_options
+  when: item.value != ""
+  sudo: yes
   notify:
     - restart chronos
   tags:
     - chronos
 
-- name: enable and start chronos
+- name: set sysconfig variable
+  lineinfile:
+    dest: "{{ chronos_sysconfig_path }}"
+    line: "{{ item.key }}={{ item.value }}"
+    create: yes
+  with_dict: chronos_sysconfig_vars
+  when: item.value != ""
+  sudo: yes
+  notify:
+    - restart chronos
+
+- name: enable chronos service
   sudo: yes
   service:
     enabled: yes
     name: chronos
-    state: started
   tags:
     - chronos
 
-- meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,5 +15,3 @@
 - name: Delete old slave info to ensure clean startup of Chronos after an upgrade
   file: path=/tmp/mesos/meta/slaves/latest state=absent
 
-- name: Start Chronos service
-  service: name=chronos state=restarted enabled=yes

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,9 +1,19 @@
 os_version: "{{ ansible_lsb.release if ansible_lsb is defined else ansible_distribution_version }}"
-os_version_major: "{{ os_version | regex_replace('^([0-9]+)[^0-9]*.*', '\\\\1') }}"
+os_version_major: "
+  {%- if ansible_distribution == 'Amazon' -%}
+    {{- 6 if '2014' in os_version or ('2015' in os_version and os_version[os_version.index('.'):] | int <= 3) else 7 -}}
+  {%- else -%}
+    {%- if ansible_distribution_major_version is defined -%}
+      {{- ansible_distribution_major_version -}}
+    {%- elif '.' in os_version %}
+      {{- os_version[:os_version.index('.')] -}}
+    {%- else -%}
+      {{- os_version -}}
+    {%- endif -%}
+  {%- endif -%}
+  "
 
 mesosphere_releases:
   '6': 'mesosphere-el-repo-6-3.noarch.rpm'
-  '7': 'mesosphere-el-repo-7-1.noarch.rpm'
-
-mesosphere_repo: "http://repos.mesosphere.com/el/{{ os_version_major }}/noarch/RPMS/{{ mesosphere_releases[os_version_major] }}"
+  '7': 'mesosphere-el-repo-7-3.noarch.rpm'
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-chronos_playbook_version: "0.2.0"
+chronos_playbook_version: "0.3.0"


### PR DESCRIPTION
Move hard coded values into defaults.
Workaround some issues more elegantly.
Make some tasks optional, they seemed issue fixes for specific installation.
Add test using Vagrant, works on CentOS 7 and Ubuntu Trusty.
Fix Chronos always binding to loopback and warning about it, using LIBPROCESS_IP variable.
Drop "reload chronos" handler, see #6.

I tried to retain most of the original behavior but I had to drop some as they are not at the core of Chronos, like Zookeeper ACL. Also, HAProxy is not working because of #5. 
